### PR TITLE
Don't create duplicate styles, bug #4

### DIFF
--- a/detect-element-resize.js
+++ b/detect-element-resize.js
@@ -72,6 +72,7 @@
 			}
 
 			head.appendChild(style);
+			stylesCreated = true;
 		}
 	}
 	

--- a/jquery.resize.js
+++ b/jquery.resize.js
@@ -89,6 +89,7 @@
 			}
 
 			head.appendChild(style);
+			stylesCreated = true;
 		}
 	}
 	


### PR DESCRIPTION
Messing with the styles too often causes a major perf hit. This fix reduces my particular page's load time from 8s on chrome to about 2s (a complex angularjs page).
