### PR TITLE
Added package.json for NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "javascript-detect-element-resize",
+  "version": "0.5.3",
+  "description": "A Cross-Browser, Event-based, Element Resize Detection",
+  "main": "detect-element-resize.js",
+  "directories": {
+    "test": "tests"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sdecima/javascript-detect-element-resize"
+  },
+  "keywords": [
+    "resize",
+    "events"
+  ],
+  "author": "Sebastián Décima (https://github.com/sdecima/)",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/sdecima/javascript-detect-element-resize/issues"
+  },
+  "homepage": "https://github.com/sdecima/javascript-detect-element-resize",
+  "devDependencies": {
+    "browserify": "^6.3.3"
+  }
+}


### PR DESCRIPTION
I added a package.json so the module can be installed as an NPM package with Browserify.

With this you can install the package with npm:

```
$ npm install git+https://github.com/sverrejoh/javascript-detect-element-resize
```

And then use the page with require from your Browserify project:

```
// Content of index.js
require("javascript-detect-element-resize");
```

Build into one bundle containing everything with Browserify:

```
browserify index.js > bundle.js
```

I didn't change the code at all, this is just metadata. 

I think it would be nice if the package had its own namespace, which exported  `addResizeListener` and `removeResizeListener`, so you could use the code like this (instead of putting it on window):

```
var detectResize = require("javascript-detect-element-resize");
detectResize.addResizeListener(element, func);
```

But this requires some change in your code, and build step, so I didn't want to start on it.

Using Browserify you could have the canonical version as a Browserify/CommonJS module, and then just from that generate a package that works standalone, or with AMD/Bower.

https://github.com/substack/browserify-handbook#standalone

As I said, a little bit of changes, but I'd love to help if you're interested :).
