### PR TITLE
Fixed issue where the resize-trigger div would hide sibling elements (observed in iOS WebView).

### DIFF
--- a/detect-element-resize.js
+++ b/detect-element-resize.js
@@ -93,7 +93,7 @@
 			//opacity:0 works around a chrome bug https://code.google.com/p/chromium/issues/detail?id=286360
 			var css = (animationKeyframes ? animationKeyframes : '') +
 					'.resize-triggers { ' + (animationStyle ? animationStyle : '') + 'visibility: hidden; opacity: 0; } ' +
-					'.resize-triggers, .resize-triggers > div, .contract-trigger:before { content: \" \"; display: block; position: absolute; top: 0; left: 0; height: 100%; width: 100%; overflow: hidden; } .resize-triggers > div { background: #eee; overflow: auto; } .contract-trigger:before { width: 200%; height: 200%; }',
+					'.resize-triggers, .resize-triggers > div, .contract-trigger:before { content: \" \"; display: block; position: absolute; top: 0; left: 0; height: 100%; width: 100%; overflow: hidden; z-index: -1; } .resize-triggers > div { background: #eee; overflow: auto; } .contract-trigger:before { width: 200%; height: 200%; }',
 				head = document.head || document.getElementsByTagName('head')[0],
 				style = document.createElement('style');
 			

--- a/jquery.resize.js
+++ b/jquery.resize.js
@@ -110,7 +110,7 @@
 			//opacity:0 works around a chrome bug https://code.google.com/p/chromium/issues/detail?id=286360
 			var css = (animationKeyframes ? animationKeyframes : '') +
 					'.resize-triggers { ' + (animationStyle ? animationStyle : '') + 'visibility: hidden; opacity: 0; } ' +
-					'.resize-triggers, .resize-triggers > div, .contract-trigger:before { content: \" \"; display: block; position: absolute; top: 0; left: 0; height: 100%; width: 100%; overflow: hidden; } .resize-triggers > div { background: #eee; overflow: auto; } .contract-trigger:before { width: 200%; height: 200%; }',
+					'.resize-triggers, .resize-triggers > div, .contract-trigger:before { content: \" \"; display: block; position: absolute; top: 0; left: 0; height: 100%; width: 100%; overflow: hidden; z-index: -1; } .resize-triggers > div { background: #eee; overflow: auto; } .contract-trigger:before { width: 200%; height: 200%; }',
 				head = document.head || document.getElementsByTagName('head')[0],
 				style = document.createElement('style');
 			


### PR DESCRIPTION
Sibling elements to the resize-trigger div where being hidden, this change fixes that issue.

This issue was observed and reproducible in the iOS8 UIWebView.
