### PR TITLE
Add support for standard jQuery bind method on/one/off 'resize' event

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,10 @@ jQuery plugin library usage
     /* do something */
   };
   
-  $('#resizeElement').resize(myFunc);
-  $('#resizeElement').removeResize(myFunc);
+  $('#resizeElement').on('resize', myFunc);
+  // or
+  // $('#resizeElement').resize(myFunc);
+  $('#resizeElement').off('resize', myFunc);
 </script>
 ```
 
@@ -75,7 +77,6 @@ TODO
 
  - Fix detach/re-attach issue on IE 10 and below (IE 9 and below doesn't support CSS animations so we can use those as in the rest of the browsers).
  - Create minified version of the libraries.
- - Add support for standard jQuery bind method on 'resize' event.
 
 Release Notes
 =============

--- a/jquery.resize.js
+++ b/jquery.resize.js
@@ -11,22 +11,48 @@
 	var attachEvent = document.attachEvent,
 		stylesCreated = false;
 	
-	var jQuery_resize = $.fn.resize;
-	
-	$.fn.resize = function(callback) {
-		return this.each(function() {
-			if(this == window)
-				jQuery_resize.call(jQuery(this), callback);
-			else
-				addResizeListener(this, callback);
+	function installResizeListener($el) {
+		$el.each(function () {
+			var installed = this.__resizeListeners__
+							&& this.__resizeListeners__.indexOf(triggerResizeListener) !== -1;
+
+			if (this !== window && !installed) {
+				addResizeListener(this, triggerResizeListener);
+			}
 		});
 	}
 
-	$.fn.removeResize = function(callback) {
-		return this.each(function() {
-			removeResizeListener(this, callback);
-		});
+	function triggerResizeListener() {
+		var element = this;
+
+		$(element).triggerHandler('resize');
 	}
+
+	var resizeRegTest = /\bresize\b/;
+	var jQuery_on = $.fn.on;
+	var jQuery_one = $.fn.one;
+
+	$.fn.on = function() {
+		var types = arguments[0];
+
+		if (resizeRegTest.test(types)) {
+			installResizeListener(this);
+		}
+		return jQuery_on.apply(this, arguments);
+	};
+
+	$.fn.one = function() {
+		var types = arguments[0];
+
+		if (resizeRegTest.test(types)) {
+			installResizeListener(this);
+		}
+		return jQuery_one.apply(this, arguments);
+	};
+	// compatibility for v0.5.3 and below
+	$.fn.removeResize = function(callback) {
+		return $.fn.off.apply(this, ['resize', callback]);
+	};
 	
 	if (!attachEvent) {
 		var requestFrame = (function(){
@@ -52,7 +78,7 @@
 			expandChild.style.height = expand.offsetHeight + 1 + 'px';
 			expand.scrollLeft = expand.scrollWidth;
 			expand.scrollTop = expand.scrollHeight;
-		};
+		}
 
 		function checkTriggers(element){
 			return element.offsetWidth != element.__resizeLast__.width ||
@@ -72,7 +98,7 @@
 					});
 				}
 			});
-		};
+		}
 		
 		/* Detect CSS Animations support to detect element display/re-attach */
 		var animation = false,
@@ -160,5 +186,5 @@
 					element.__resizeTriggers__ = !element.removeChild(element.__resizeTriggers__);
 			}
 		}
-	}
+	};
 }( jQuery ));

--- a/tests/tests-javascript.html
+++ b/tests/tests-javascript.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="utf-8">
   <title>javascript-detect-element-resize Tests</title>
-  <link rel="stylesheet" href="//code.jquery.com/qunit/qunit-1.15.0.css">
+  <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-1.15.0.css">
   <link rel="stylesheet" href="tests.css">
 </head>
 <body>
   <div id="qunit"></div>
   <div id="qunit-fixture"></div>
-  <script src="//code.jquery.com/qunit/qunit-1.15.0.js"></script>
-  <script src="//code.jquery.com/jquery-1.11.1.min.js"></script>
+  <script src="https://code.jquery.com/qunit/qunit-1.15.0.js"></script>
+  <script src="https://code.jquery.com/jquery-1.11.1.min.js"></script>
   <script src="../detect-element-resize.js"></script>
   <script src="tests-javascript.js"></script>
 </body>

--- a/tests/tests-jquery.html
+++ b/tests/tests-jquery.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="utf-8">
   <title>javascript-detect-element-resize Tests</title>
-  <link rel="stylesheet" href="//code.jquery.com/qunit/qunit-1.15.0.css">
+  <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-1.15.0.css">
   <link rel="stylesheet" href="tests.css">
 </head>
 <body>
   <div id="qunit"></div>
   <div id="qunit-fixture"></div>
-  <script src="//code.jquery.com/qunit/qunit-1.15.0.js"></script>
-  <script src="//code.jquery.com/jquery-1.11.1.min.js"></script>
+  <script src="https://code.jquery.com/qunit/qunit-1.15.0.js"></script>
+  <script src="https://code.jquery.com/jquery-1.11.1.min.js"></script>
   <script src="../jquery.resize.js"></script>
   <script src="tests-jquery.js"></script>
 </body>

--- a/tests/tests-jquery.js
+++ b/tests/tests-jquery.js
@@ -10,7 +10,7 @@ QUnit.module('main', {
     content = document.getElementById('content');
 
     $('#container').hide();
-    $(element).resize(detectCallback);
+    $(element).on('resize', detectCallback);
     $('#container').show();
     shouldDetect = true;
     detected = false;
@@ -18,7 +18,7 @@ QUnit.module('main', {
   teardown: function() {
     $('#styleTest').remove();
     try {
-      $(element).removeResize(detectCallback);
+      $(element).off('resize', detectCallback);
     } catch(e) {}
   }
 });
@@ -81,7 +81,7 @@ QUnit.asyncTest( "JS removeResizeListener test", function( assert ) {
   newWidth = 0;
   shouldDetect = false;
   
-  $(element).removeResize(detectCallback);
+  $(element).off('resize', detectCallback);
   
   $(content).width(newWidth);
   $(content).height(0);


### PR DESCRIPTION
Simply call `$('div').on('resize', callback)`, `$('div').one('resize', callback)`, `$('div').resize(callback)` and `$('div').off('resize', callback)` are all OK!
