### PR TITLE
Fix missing semicolon

### DIFF
--- a/jquery.resize.js
+++ b/jquery.resize.js
@@ -20,13 +20,13 @@
 			else
 				addResizeListener(this, callback);
 		});
-	}
+	};
 
 	$.fn.removeResize = function(callback) {
 		return this.each(function() {
 			removeResizeListener(this, callback);
 		});
-	}
+	};
 	
 	if (!attachEvent) {
 		var requestFrame = (function(){


### PR DESCRIPTION
If you will try to minimize jquery.resize.js you will get the syntax error, it's because of missing semicolons.
This PR fixes it.
